### PR TITLE
#23 bucket should no longer use random provider

### DIFF
--- a/journal/week1.md
+++ b/journal/week1.md
@@ -49,3 +49,25 @@ This is the default file to load in terraform variables in blunk
 ### order of terraform variables
 
 - TODO: document which terraform variables takes presendence.
+
+
+## Dealing With Configuration Drift
+
+## What happens if we lose our state file?
+
+If you lose your statefile, you must likely have to tear down all your cloud infrastructures manually.
+
+You can use terraform import but it won't work for all cloud resources. You need to check the terraform providers documentation for which resources that support import.
+
+### Fix Missing Resources with Terraform Import
+
+`terraform import aws_s3_bucket.bucket bucket-name`
+
+[Terraform Import](https://developer.hashicorp.com/terraform/cli/import)
+[AWS S3 Bucket Import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+
+### Fix Manual Configuration
+
+If someone goes and delete or modifies cloud resource manually through ClickOps. 
+
+If we run Terraform plan with attempt to put our infrastructure back into the expected state fixing Configuration Drift

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,8 @@
-# https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
-resource "random_string" "bucket_name" {
-  lower = true
-  upper = false
-  length   = 32
-  special  = false
-}
-
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "website_bucket" {
   # Bucket Naming Rules
   #https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html?icmpid=docs_amazons3_console
-  bucket = random_string.bucket_name.result
+  bucket = var.bucket_name
 
   tags = {
     UserUuid = var.user_uuid

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket.bucket
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,17 +7,13 @@ terraform {
   #    name = "terra-house-1"
   #  }
   #}
-#   cloud {
-#    organization = "terraformer-bootcamp-2023"
-#    workspaces {
-#      name = "terra-house-1"
-#    }
-#   }
+  #cloud {
+  #  organization = "terraformer-bootcamp-2023"
+  #  workspaces {
+  #    name = "terra-house-1"
+  #  }
+  #}
   required_providers {
-    random = {
-      source = "hashicorp/random"
-      version = "3.5.1"
-    }
     aws = {
       source = "hashicorp/aws"
       version = "5.16.2"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="e2977999-dd8f-4ef3-8edc-cb445f106337"
+bucket_name="terraform-bootcampx2uozqdfbdj9f2l"

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,16 @@ variable "user_uuid" {
     error_message    = "The user_uuid value is not a valid UUID."
   }
 }
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+
+  validation {
+    condition     = (
+      length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
+      can(regex("^[a-z0-9][a-z0-9-.]*[a-z0-9]$", var.bucket_name))
+    )
+    error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
+  }
+}


### PR DESCRIPTION
 - [x] use terraform import
 - [x] purposely cause configuration drift via clickops, and correct state.